### PR TITLE
Add a workaround to fix broken DNS resolution after bootstrapping

### DIFF
--- a/roles/agent/tasks/agent.yml
+++ b/roles/agent/tasks/agent.yml
@@ -98,6 +98,12 @@
     timeout: 60
   tags: bootstrap
 
+- name: Restart network service (fix broken name resolution)
+  service:
+    name: network
+    state: restarted
+  tags: bootstrap
+
 - name: Inform NodeManager that the agents are installed
   mockfog_send_status:
     nodemanager: http://localhost:7474


### PR DESCRIPTION
**Fixed Issue**
After bootstrapping a MockFog instance DNS resolution didn't seem to work properly (no names were resolved at all). Restarting the network service fixes that.

**I have no idea where the issue came from nor why the fix works!!!** (I assume it is somehow related to the Amazon network customizations properly setting the DNS server on service or instance restart but that is just a half-educated guess...)

**Please reproduce the issue first before merging this!**
@MoeweX @martingrambow 