### PR TITLE
Fix restricted network communication within MockFog network

### DIFF
--- a/roles/aws-bootstrap/tasks/bootstrap.yml
+++ b/roles/aws-bootstrap/tasks/bootstrap.yml
@@ -123,7 +123,7 @@
   ec2_eni:
     aws_access_key: "{{ ec2_access_key }}"
     aws_secret_key: "{{ ec2_secret_access_key }}"
-    security_groups: "{{ public_security_group.group_id }}"
+    security_groups: "{{ security_group.group_id }}"
     state: present
     attached: True
     device_index: 1


### PR DESCRIPTION
This fixes the network communication between MockFog nodes, which was too restrictive before (due to the wrongly assigned public security group on the MockFog interface).
The MockFog security group effectively removes any restrictions from internal MockFog communication.